### PR TITLE
chore: create nat gateway in e2e network

### DIFF
--- a/tests/e2etest-network/main.k
+++ b/tests/e2etest-network/main.k
@@ -89,8 +89,12 @@ _rta_external_names = {
 # NAT Gateways (populate after first run with NAT enabled)
 # Get NAT IDs: kubectl get natgateway -l crossplane.io/composite=hops-test -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.status.atProvider.id}{"\n"}{end}'
 # Get EIP IDs: kubectl get eip -l crossplane.io/composite=hops-test -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.status.atProvider.allocationId}{"\n"}{end}'
-_nat_external_names = {}
-_eip_external_names = {}
+_nat_external_names = {
+    "a": "nat-05a5e2c13be4c716a"
+}
+_eip_external_names = {
+    "a": "eipalloc-09da84030949b878c"
+}
 
 # =============================================================================
 # Test Network

--- a/tests/e2etest-network/main.k
+++ b/tests/e2etest-network/main.k
@@ -86,8 +86,9 @@ _rta_external_names = {
     "private-c": "rtbassoc-0f81cf5c3e798aa8c"
 }
 
-# NAT Gateways
-# No NAT Gateways found
+# NAT Gateways (populate after first run with NAT enabled)
+# Get NAT IDs: kubectl get natgateway -l crossplane.io/composite=hops-test -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.status.atProvider.id}{"\n"}{end}'
+# Get EIP IDs: kubectl get eip -l crossplane.io/composite=hops-test -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.status.atProvider.allocationId}{"\n"}{end}'
 _nat_external_names = {}
 _eip_external_names = {}
 
@@ -214,9 +215,13 @@ _items = [
                                 if _rta_external_names:
                                     associationExternalNames: _rta_external_names
                             }
-                        # No NAT gateway (costs money)
                         nat: {
-                            enabled: False
+                            enabled: True
+                            strategy: "SingleAz"
+                            if _nat_external_names:
+                                externalNames: _nat_external_names
+                            if _eip_external_names:
+                                eipExternalNames: _eip_external_names
                         }
                     }
                 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * NAT gateways enabled in test configuration with SingleAz deployment.
  * External name and EIP integration points added; mappings supported and referenced when provided.
  * Test documentation updated with header changes and inline commands to obtain NAT/EIP IDs.
  * NAT enablement applied across multiple network blocks for consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->